### PR TITLE
CmsBrowserPlugin: Fix redirect OnCancel for new nodes

### DIFF
--- a/src/Premotion.Mansion.Web/Web/Types/CmsBrowserPlugin/CmsBrowserPlugin.xinclude
+++ b/src/Premotion.Mansion.Web/Web/Types/CmsBrowserPlugin/CmsBrowserPlugin.xinclude
@@ -134,7 +134,7 @@
 
 		<!-- default action for form submits -->
 		<declareProcedure procedureName="OnCancel">
-			<web:redirectRequest url="{CmsNodeUrl( FormSourceNode.id, 'CmsBrowserPlugin', 'Browse' )}?change=cancelled" />
+			<web:redirectRequest url="{CmsNodeUrl( NotEmpty(FormSourceNode.id, ParentNode.id ), 'CmsBrowserPlugin', 'Browse' )}?change=cancelled" />
 			<breakExecution />
 		</declareProcedure>
 


### PR DESCRIPTION
Redirecting to the parent node when cancelling a new node creation. When canceling a new node, the browser got redirected to the root level.
