### PR TITLE
WindowsContentResourceService ParsePath shouldn't use categoryBasePath when checking for an resource

### DIFF
--- a/src/Premotion.Mansion.Core/IO/Windows/WindowsContentResourceService.cs
+++ b/src/Premotion.Mansion.Core/IO/Windows/WindowsContentResourceService.cs
@@ -153,7 +153,7 @@ namespace Premotion.Mansion.Core.IO.Windows
 			// check if it is an existing resource
 			string relativePath;
 			if (properties.TryGet(context, "relativePath", out relativePath))
-				return new ContentResourcePath(ResourceUtils.Combine(categoryBasePath, relativePath));
+				return new ContentResourcePath(relativePath);
 
 			// check if it is a new file name
 			string fileName;


### PR DESCRIPTION
ParsePath shouldn't use categoryBasePath when checking for an existing resource.
It tried to look for /uploads/uploads/2013/10/3/file.ext (double 'uploads/' directory).

The categoryBasePath should only be used for a new file. This is how the Amazon S3 Content Resource Service is working too.
