### PR TITLE
LoopTag bugfix incorrect starting index

### DIFF
--- a/src/Premotion.Mansion.Core/Premotion.Mansion.Core.csproj
+++ b/src/Premotion.Mansion.Core/Premotion.Mansion.Core.csproj
@@ -406,6 +406,7 @@
     <Compile Include="Scripting\TagScript\AlternativeScriptTag.cs" />
     <Compile Include="Scripting\TagScript\AttributeNotSpecifiedException.cs" />
     <Compile Include="Scripting\TagScript\AttributeNullException.cs" />
+    <Compile Include="Scripting\TagScript\AttributeOutOfRangeException.cs" />
     <Compile Include="Scripting\TagScript\ITagScript.cs" />
     <Compile Include="Scripting\TagScript\ITagScriptService.cs" />
     <Compile Include="Scripting\TagScript\ScriptTagAttribute.cs" />

--- a/src/Premotion.Mansion.Core/ScriptTags/LoopTag.cs
+++ b/src/Premotion.Mansion.Core/ScriptTags/LoopTag.cs
@@ -1,3 +1,4 @@
+using System;
 using Premotion.Mansion.Core.Collections;
 using Premotion.Mansion.Core.ScriptTags.Stack;
 using Premotion.Mansion.Core.Scripting.TagScript;
@@ -21,16 +22,21 @@ namespace Premotion.Mansion.Core.ScriptTags
 			var start = GetRequiredAttribute<int>(context, "start");
 			var end = GetRequiredAttribute<int>(context, "end");
 
+			// validate arguments
+			if (start < 0)
+				throw new AttributeOutOfRangeException("start", this);
+			if (end < 0 || end < start)
+				throw new AttributeOutOfRangeException("end", this);
+
 			// create the dataset
 			var dataset = new Dataset();
 
 			// fill the dataset
 			for (var index = start; index <= end; index++)
 			{
-				dataset.AddRow(new PropertyBag
-				               {
-				               	{"index", index}
-				               });
+				dataset.AddRow(new PropertyBag {
+					{"index", index}
+				});
 			}
 
 			return dataset;

--- a/src/Premotion.Mansion.Core/ScriptTags/Stack/LoopBaseTag.cs
+++ b/src/Premotion.Mansion.Core/ScriptTags/Stack/LoopBaseTag.cs
@@ -22,9 +22,7 @@ namespace Premotion.Mansion.Core.ScriptTags.Stack
 			var dataset = GetLoopset(context);
 
 			// create the loop
-			var start = GetAttribute(context, "start", 0);
-			var end = Math.Max(start, GetAttribute(context, "end", dataset.RowCount - 1));
-			var loop = new Loop(new DatasetReader(dataset), start, end);
+			var loop = new Loop(new DatasetReader(dataset), 0, dataset.RowCount);
 
 			// push the loop to the stack
 			using (context.Stack.Push("Loop", loop))

--- a/src/Premotion.Mansion.Core/Scripting/TagScript/AttributeOutOfRangeException.cs
+++ b/src/Premotion.Mansion.Core/Scripting/TagScript/AttributeOutOfRangeException.cs
@@ -1,0 +1,44 @@
+﻿using System;
+
+namespace Premotion.Mansion.Core.Scripting.TagScript
+{
+	/// <summary>
+	/// This exception is thrown when a attribute is out of range on a <see cref="ScriptTag"/>.
+	/// </summary>
+	public class AttributeOutOfRangeException : ApplicationException
+	{
+		#region Constructors
+		///<summary>
+		///</summary>
+		///<param name="attributeName"></param>
+		///<param name="scriptTag"></param>
+		public AttributeOutOfRangeException(string attributeName, ScriptTag scriptTag)
+		{
+			// validate arguments
+			if (string.IsNullOrEmpty(attributeName))
+				throw new ArgumentNullException("attributeName");
+			if (scriptTag == null)
+				throw new ArgumentNullException("scriptTag");
+
+			// format the exception message
+			message = string.Format("The attribute '{0}' is out of range on tag of type '{1}'", attributeName, scriptTag.GetType());
+		}
+		#endregion
+		#region Overrides of Exception
+		/// <summary>
+		/// Gets a message that describes the current exception.
+		/// </summary>
+		/// <returns>
+		/// The error message that explains the reason for the exception, or an empty string("").
+		/// </returns>
+		/// <filterpriority>1</filterpriority>
+		public override string Message
+		{
+			get { return message; }
+		}
+		#endregion
+		#region Private Fields
+		private readonly string message;
+		#endregion
+	}
+}


### PR DESCRIPTION
Fixes an issue where the starting index is incorrect when starting the loop from anything else but zero.

How to reproduce the bug:

``` xml
<loop start="1" end="3" target="Loop">
    <renderText>Index at{Loop.index}, </renderText>
</loop>
```

This example outputs `Index at2, Index at3,`, while the expected result is `Index at1, Index at2, Index at3,`

At first a dataset was created for the loop, starting at `start` and ending at `end`. After that, a Loop was created that also started at `start`, doing so it skipped the first row of the dataset.

The change I made will always create a Loop from 0 to the amount of rows in the dataset, making the `GetLoopset` responsible for validating the attributes. This is done because in some cases (end < start) an empty dataset is created and returned, thus not throwing an out of range exception.

Just like the `ArgumentOutOfRangeException`, a `AttributeOutOfRangeException` is created.
