### PR TITLE
Loop.current bug introduced by issue #152

### DIFF
--- a/src/Premotion.Mansion.Core/Collections/Loop.cs
+++ b/src/Premotion.Mansion.Core/Collections/Loop.cs
@@ -31,7 +31,7 @@ namespace Premotion.Mansion.Core.Collections
 			Reader = reader;
 			Start = start;
 			End = end;
-			offset = 0;
+			offset = start;
 		}
 		/// <summary>
 		/// Constructs a loop for the specified dataset.
@@ -107,7 +107,7 @@ namespace Premotion.Mansion.Core.Collections
 			get
 			{
 				Current = offset;
-				var loopCurrent = 0;
+				var loopCurrent = start;
 				foreach (var row in Reader)
 				{
 					if (loopCurrent >= start && loopCurrent <= End)

--- a/src/Premotion.Mansion.Core/ScriptTags/LoopTag.cs
+++ b/src/Premotion.Mansion.Core/ScriptTags/LoopTag.cs
@@ -28,16 +28,15 @@ namespace Premotion.Mansion.Core.ScriptTags
 			if (end < 0 || end < start)
 				throw new AttributeOutOfRangeException("end", this);
 
+			Start = start;
+			End = end;
+
 			// create the dataset
 			var dataset = new Dataset();
 
 			// fill the dataset
 			for (var index = start; index <= end; index++)
-			{
-				dataset.AddRow(new PropertyBag {
-					{"index", index}
-				});
-			}
+				dataset.AddRow(new PropertyBag());
 
 			return dataset;
 		}

--- a/src/Premotion.Mansion.Core/ScriptTags/Repository/LoopNodesetTag.cs
+++ b/src/Premotion.Mansion.Core/ScriptTags/Repository/LoopNodesetTag.cs
@@ -18,7 +18,9 @@ namespace Premotion.Mansion.Core.ScriptTags.Repository
 		/// <returns>Returns the <see cref="Dataset"/> on which to loop.</returns>
 		protected override Dataset GetLoopset(IMansionContext context)
 		{
-			return GetRequiredAttribute<Nodeset>(context, "source");
+			var loopset = GetRequiredAttribute<Nodeset>(context, "source");
+			End = loopset.RowCount;
+			return loopset;
 		}
 	}
 }

--- a/src/Premotion.Mansion.Core/ScriptTags/Stack/LoopBaseTag.cs
+++ b/src/Premotion.Mansion.Core/ScriptTags/Stack/LoopBaseTag.cs
@@ -9,6 +9,18 @@ namespace Premotion.Mansion.Core.ScriptTags.Stack
 	/// </summary>
 	public abstract class LoopBaseTag : ScriptTag
 	{
+		#region Protected Fields
+		/// <summary>
+		/// Start of the loop
+		/// </summary>
+		protected int Start = 0;
+
+		/// <summary>
+		/// End of the loop
+		/// </summary>
+		protected int End = 0;
+		#endregion
+
 		/// <summary>
 		/// </summary>
 		/// <param name="context"></param>
@@ -22,7 +34,7 @@ namespace Premotion.Mansion.Core.ScriptTags.Stack
 			var dataset = GetLoopset(context);
 
 			// create the loop
-			var loop = new Loop(new DatasetReader(dataset), 0, dataset.RowCount);
+			var loop = new Loop(new DatasetReader(dataset), Start, End);
 
 			// push the loop to the stack
 			using (context.Stack.Push("Loop", loop))

--- a/src/Premotion.Mansion.Core/ScriptTags/Stack/LoopDatasetTag.cs
+++ b/src/Premotion.Mansion.Core/ScriptTags/Stack/LoopDatasetTag.cs
@@ -16,7 +16,9 @@ namespace Premotion.Mansion.Core.ScriptTags.Stack
 		/// <returns>Returns the <see cref="Dataset"/> on which to loop.</returns>
 		protected override Dataset GetLoopset(IMansionContext context)
 		{
-			return GetRequiredAttribute<Dataset>(context, "source");
+			var loopset = GetRequiredAttribute<Dataset>(context, "source");
+			End = loopset.RowCount;
+			return loopset;
 		}
 	}
 }


### PR DESCRIPTION
Breaking change for code using `{Loop.index}`!

This change removes the `index` property from the target dataspace within the **LoopTag**.
The `index` property was only available on the **LoopTag**, but not on the **LoopNodesetTag** or **LoopDatasetTag**.

`Loop.Current` should always be used, just like that is used when looping on datasets or nodesets.

The only problem I am still facing is that a target with the name `Loop` can be given, thus masking the Loop dataspace containing `Current` that was put on the stack by the **LoopTag**:

``` xml
<loop start="1" end="3" target="Loop">
    <renderText>Index at {Loop.Current}, </renderText>
</loop>
```

Result: `Index at , Index at , Index at ,`

---

``` xml
<loop start="1" end="3" target="Row">
    <renderText>Index at {Loop.Current}, </renderText>
</loop>
```

Result: `Index at 1, Index at 2, Index at 3,`

Maybe a xs:restriction can be added with the pattern `^((?!Loop$)).*$`? 

@trilobyte What do you think?
