### PR TITLE
Revert adding the table to the query on the AllowedRolesComponentConverter

### DIFF
--- a/src/Premotion.Mansion.Repository.SqlServer/Queries/Converters/Nodes/AllowedRolesComponentConverter.cs
+++ b/src/Premotion.Mansion.Repository.SqlServer/Queries/Converters/Nodes/AllowedRolesComponentConverter.cs
@@ -26,9 +26,6 @@ namespace Premotion.Mansion.Repository.SqlServer.Queries.Converters.Nodes
 			// get the table in which the column exists from the schema
 			var pair = commandContext.Schema.FindTableAndColumn("allowedRoleGuids");
 
-			// add the table to the query
-			commandContext.QueryBuilder.AddTable(context, pair.Table, commandContext.Command);
-
 			// assemble the properties
 			var buffer = new StringBuilder();
 			foreach (var value in specification.RoleIds)


### PR DESCRIPTION
Somehow this one messes up the backoffice and some other queries.
![image](https://cloud.githubusercontent.com/assets/1898162/2832802/a338d508-cfc8-11e3-8a6c-53748966bc27.png)
