### PR TITLE
Revert adding the table to the query for the in specification converter...

### DIFF
--- a/src/Premotion.Mansion.Repository.SqlServer/Queries/Converters/IsPropertyInSpecificationConverter.cs
+++ b/src/Premotion.Mansion.Repository.SqlServer/Queries/Converters/IsPropertyInSpecificationConverter.cs
@@ -20,9 +20,6 @@ namespace Premotion.Mansion.Repository.SqlServer.Queries.Converters
 			// get the table in which the column exists from the schema
 			var pair = commandContext.Schema.FindTableAndColumn(specification.PropertyName);
 
-			// add the table to the query
-			commandContext.QueryBuilder.AddTable(context, pair.Table, commandContext.Command);
-
 			// allow the table to map the value
 			pair.Column.ToWhereStatement(context, commandContext, specification.Values);
 		}


### PR DESCRIPTION
...because it triggers unexpected query behavior in front-end queries.

Nodes are double selected, just as #157 triggered unexpected behavior in the back-end.
