### PR TITLE
Add 'yyyy-MM-dd' to the allowed formats for the StringToDateTimeConverter

### DIFF
--- a/src/Premotion.Mansion.Core/Conversion/Converters/StringToDateTimeConverter.cs
+++ b/src/Premotion.Mansion.Core/Conversion/Converters/StringToDateTimeConverter.cs
@@ -9,7 +9,7 @@ namespace Premotion.Mansion.Core.Conversion.Converters
 	public class StringToDateTimeConverter : ConverterBase<string, DateTime>
 	{
 		#region Constants
-		private static readonly string[] Formats = new[] {"r", "U", "f", "F", "d", "D", "yyyy-MM-dd HH:mm:ss", "yyyy-MM-dd HH:mm", "yyyy/MM/dd HH:mm:ss", "yyyy/MM/dd HH:mm", "yyyy/MM/dd", "dd-MM-yyyy HH:mm:ss", "dd-MM-yyyy HH:mm", "dd-MM-yyyy", "d MMMM yyyy HH:mm:ss", "d MMMM yyyy HH:mm", "d MMMM yyyy"};
+		private static readonly string[] Formats = new[] {"r", "U", "f", "F", "d", "D", "yyyy-MM-dd HH:mm:ss", "yyyy-MM-dd HH:mm", "yyyy-MM-dd", "yyyy/MM/dd HH:mm:ss", "yyyy/MM/dd HH:mm", "yyyy/MM/dd", "dd-MM-yyyy HH:mm:ss", "dd-MM-yyyy HH:mm", "dd-MM-yyyy", "d MMMM yyyy HH:mm:ss", "d MMMM yyyy HH:mm", "d MMMM yyyy"};
 		#endregion
 		#region Overrides of ConverterBase<string,DateTime>
 		/// <summary>


### PR DESCRIPTION
This is needed for the sql date type.
In my case, I have a type table with a column of the type 'date'.

Some problems that occured:
Because the framework does not parse 'yyyy-MM-dd'...
1) date values on xforms are empty 
2) the FormatDate scriptfunction can't handle this type of date.
3) ...
