### PR TITLE
Fix ScriptFunction IsFalse return value.

### DIFF
--- a/src/Premotion.Mansion.Core/ScriptFunctions/Conditional/IsFalse.cs
+++ b/src/Premotion.Mansion.Core/ScriptFunctions/Conditional/IsFalse.cs
@@ -39,7 +39,7 @@ namespace Premotion.Mansion.Core.ScriptFunctions.Conditional
 				throw new ArgumentNullException("context");
 
 			// convert the value
-			return conversionService.Convert(context, input, true);
+			return (conversionService.Convert(context, input, true) == false);
 		}
 		#endregion
 		#region Private Fields


### PR DESCRIPTION
The ScriptFunction returned the input boolean itself, instead of the boolean indicating if the input was false.
