### PR TITLE
DoAfterCreate listeners should receive properties prefixed with an underscore.

### DIFF
--- a/src/Premotion.Mansion.Repository.SqlServer/Schemas/ExtendedPropertiesColumn.cs
+++ b/src/Premotion.Mansion.Repository.SqlServer/Schemas/ExtendedPropertiesColumn.cs
@@ -26,19 +26,20 @@ namespace Premotion.Mansion.Repository.SqlServer.Schemas
 		/// </summary>
 		/// <param name="context"></param>
 		/// <param name="queryBuilder"></param>
-		/// <param name="properties"></param>
-		protected override void DoToInsertStatement(IMansionContext context, ModificationQueryBuilder queryBuilder, IPropertyBag properties)
+		/// <param name="newProperties"></param>
+		protected override void DoToInsertStatement(IMansionContext context, ModificationQueryBuilder queryBuilder, IPropertyBag newProperties)
 		{
+			var extendedProperties = new PropertyBag(newProperties);
 			// remove all properties starting with an underscore
-			var unstoredPropertyNames = properties.Names.Where(candidate => candidate.StartsWith("_")).ToList();
+			var unstoredPropertyNames = extendedProperties.Names.Where(candidate => candidate.StartsWith("_")).ToList();
 			foreach (var propertyName in unstoredPropertyNames)
-				properties.Remove(propertyName);
+				extendedProperties.Remove(propertyName);
 
 			// get the conversion service
 			var conversionService = context.Nucleus.ResolveSingle<IConversionService>();
 
 			// set the column value
-			queryBuilder.AddColumnValue("extendedProperties", conversionService.Convert<byte[]>(context, properties), DbType.Binary);
+			queryBuilder.AddColumnValue("extendedProperties", conversionService.Convert<byte[]>(context, extendedProperties), DbType.Binary);
 		}
 		/// <summary>
 		/// 


### PR DESCRIPTION
The removal of properties prefixed with an underscore should only be removed at insert.
DoToUpdateStatement already removes these properties in a copy propertybag. DoToInsertStatement should do this to.

This solves the problem that properties prefixed with an underscore aren't present in the propertybag in DoAfterCreate listeners.
