### PR TITLE
Add publication date for content types to the backoffice browser grid.

### DIFF
--- a/src/Premotion.Mansion.Web/Web/Types/CmsBrowserPlugin/CmsBrowserPlugin.xinclude
+++ b/src/Premotion.Mansion.Web/Web/Types/CmsBrowserPlugin/CmsBrowserPlugin.xinclude
@@ -109,7 +109,7 @@
 			<controls:expressionColumn expression="{\GetTypeDefinitionLabel( Row.type )}" heading="Type">
 				<controls:columnSort on="type" />
 			</controls:expressionColumn>
-			<if condition="{IsAssignable( CurrentNode.type, 'Content' )}">
+			<if condition="{IsAssignable( NotEmpty( Get.type, CurrentNode.type ), 'Content' )}">
 				<controls:expressionColumn expression="{\GetTypeDefinitionLabel( Row.publicationDate )}" heading="Publication date">
 					<controls:columnSort on="publicationDate" />
 				</controls:expressionColumn>


### PR DESCRIPTION
The publication date should be visible (in the backoffice browser) for content types or types inheriting from content. This also makes it easy to do a descending sort on publication date when having a large amount of content.
