### PR TITLE
Fix a typo in the .xdef of the ConfigurationPanelEntry causing the icon to fail.

### DIFF
--- a/src/Premotion.Mansion.Web.Portal/Web/Types/ConfigurationPanelEntry/ConfigurationPanelEntry.xdef
+++ b/src/Premotion.Mansion.Web.Portal/Web/Types/ConfigurationPanelEntry/ConfigurationPanelEntry.xdef
@@ -2,6 +2,6 @@
 <type inherits="DefaultIndex" xmlns="http://schemas.premotion.nl/mansion/1.0/type.definition.xsd" xmlns:cms="http://schemas.premotion.nl/mansion/1.0/web/web.cms.descriptors.xsd">
 	
 	<!-- specify cms behavior -->
-	<cms:behavior label="Configuration panel entry" abstract="true" icon="Types/ConfigurationPanelEntryt/ConfigurationPanelEntry.png" />
+	<cms:behavior label="Configuration panel entry" abstract="true" icon="Types/ConfigurationPanelEntry/ConfigurationPanelEntry.png" />
 	
 </type>


### PR DESCRIPTION
Fixed the location of the icon for ConfigurationPanelEntry types.
