### PR TITLE
Enable configuration of SMTP host and authentication

### DIFF
--- a/src/Premotion.Mansion.Web/Mail/Constants.cs
+++ b/src/Premotion.Mansion.Web/Mail/Constants.cs
@@ -1,4 +1,7 @@
-﻿namespace Premotion.Mansion.Web.Mail
+﻿using System;
+using System.Configuration;
+
+namespace Premotion.Mansion.Web.Mail
 {
 	/// <summary>
 	/// Defines constants for the web application mail library.
@@ -9,5 +12,26 @@
 		/// The namespace in which the mail tags live.
 		/// </summary>
 		public const string NamespaceUri = "http://schemas.premotion.nl/mansion/1.0/web/mail/tags.xsd";
+		/// <summary>
+		/// The name or IP address of the host used for SMTP transactions.
+		/// </summary>
+		public static string SmtpHost = ConfigurationManager.AppSettings["SMTP_HOST"];
+
+		/// <summary>
+		/// The port used for SMTP transactions.
+		/// </summary>
+		public static bool SmtpEnableSsl = Convert.ToBoolean(ConfigurationManager.AppSettings["SMTP_ENABLE_SSL"]);
+		/// <summary>
+		/// Specify wether to use SSL to encrypt the SMTP connection.
+		/// </summary>
+		public static int SmtpPort = Convert.ToInt32(ConfigurationManager.AppSettings["SMTP_PORT"]);
+		/// <summary>
+		/// The username for the SMTP network credentials.
+		/// </summary>
+		public static string SmtpUsername = ConfigurationManager.AppSettings["SMTP_USERNAME"];
+		/// <summary>
+		/// The password for the SMTP network credentials.
+		/// </summary>
+		public static string SmtpPassword = ConfigurationManager.AppSettings["SMTP_PASSWORD"];
 	}
 }

--- a/src/Premotion.Mansion.Web/Mail/Standard/StandardMailService.cs
+++ b/src/Premotion.Mansion.Web/Mail/Standard/StandardMailService.cs
@@ -19,7 +19,18 @@ namespace Premotion.Mansion.Web.Mail.Standard
 		public StandardMailService()
 		{
 			// create the client
-			smptClient = new SmtpClient();
+			smtpClient = new SmtpClient();
+
+			if (!string.IsNullOrEmpty(Constants.SmtpHost))
+				smtpClient.Host = Constants.SmtpHost;
+
+			if (Constants.SmtpPort != 0)
+				smtpClient.Port = Constants.SmtpPort;
+
+			smtpClient.EnableSsl = Constants.SmtpEnableSsl;
+
+			if (!String.IsNullOrEmpty(Constants.SmtpUsername) && !String.IsNullOrEmpty(Constants.SmtpPassword))
+				smtpClient.Credentials = new System.Net.NetworkCredential(Constants.SmtpUsername, Constants.SmtpPassword);
 		}
 		#endregion
 		#region Implementation of IMailService
@@ -64,7 +75,7 @@ namespace Premotion.Mansion.Web.Mail.Standard
 			}
 
 			// send the message
-			smptClient.Send(message);
+			smtpClient.Send(message);
 		}
 		/// <summary>
 		/// Creates an <see cref="MailMessage"/>.
@@ -89,12 +100,12 @@ namespace Premotion.Mansion.Web.Mail.Standard
 				return;
 
 			// dispose
-			if (smptClient != null)
-				smptClient.Dispose();
+			if (smtpClient != null)
+				smtpClient.Dispose();
 		}
 		#endregion
 		#region Private Fields
-		private readonly SmtpClient smptClient;
+		private readonly SmtpClient smtpClient;
 		#endregion
 	}
 }


### PR DESCRIPTION
The StandardMailService can now be configured to use an alternative SMTP host and network credentials.
