### PR TITLE
Fixed bootstrap default menu including responsiveness on mobile devices.

### DIFF
--- a/src/Premotion.Mansion.Web/Web/Cms/Cms.tpl
+++ b/src/Premotion.Mansion.Web/Web/Cms/Cms.tpl
@@ -39,18 +39,27 @@
 
 <tpl:section name="PageContainer" field="Container">
 	<div class="navbar navbar-default navbar-fixed-top">
-		<div class="navbar-header">
-			<a class="navbar-brand" href="{CmsNodeUrl( RootNode.id, 'CmsHomePlugin', 'Default' )}">Premotion Mansion CMS</a>
-		</div>
-
-		<div class="navbar-right">
-			{UserMenu}
+		<div class="container-fluid">
+			<div class="navbar-header">
+				<button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#cms-navbar-collapse-1">
+					<span class="sr-only">Toggle navigation</span>
+					<span class="icon-bar"></span>
+					<span class="icon-bar"></span>
+					<span class="icon-bar"></span>
+				</button>
+				<a class="navbar-brand" href="{CmsNodeUrl( RootNode.id, 'CmsHomePlugin', 'Default' )}">Premotion Mansion CMS</a>
+			</div>
+			<div class="navbar-collapse collapse" id="cms-navbar-collapse-1">
+				<ul class="nav navbar-nav navbar-right">
+					{UserMenu}
+				</ul>
+			</div>
 		</div>
 	</div>
 
 	<div class="container-fluid cms-page">
 		{Content}
-		<hr>
+		<hr />
 		<footer>
 			<p>&copy; Premotion Software Solutions</p>
 		</footer>

--- a/src/Premotion.Mansion.Web/Web/Cms/CmsController.tpl
+++ b/src/Premotion.Mansion.Web/Web/Cms/CmsController.tpl
@@ -1,18 +1,18 @@
 ﻿<!-- User menu section -->
 <tpl:section name="UserMenu">
-	<div class="btn-group pull-right">
-		<a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
+	<li class="dropdown">
+		<a class="dropdown-toggle" data-toggle="dropdown" href="#">
 			<i class="icon-user"></i> Welcome {User.name}
 			<span class="caret"></span>
 		</a>
-		<ul class="dropdown-menu">
+		<ul class="dropdown-menu" role="menu">
 			<li>
 				<a href="{CmsRouteUrl( 'Authentication', 'Logoff' )}" title="Sign Out">
 					<i class="icon-signout"></i>Sign Out
 				</a>
 			</li>
 		</ul>
-	</div>
+	</li>
 </tpl:section>
 
 

--- a/src/Premotion.Mansion.Web/Web/Cms/css/cms.css
+++ b/src/Premotion.Mansion.Web/Web/Cms/css/cms.css
@@ -14,7 +14,3 @@ body { padding: 0; }
 .find .search-form .facets {
 	margin-bottom: 15px;
 }
-
-.navbar div.navbar-header {
-	float: left;
-}


### PR DESCRIPTION
I've upgraded the header to bootstrap's default responsive header including hidden (mobile only) button and collapsing sub menu's.
