### PR TITLE
Given Node in DoAfterUpdate should contain modified properties

### DIFF
--- a/src/Premotion.Mansion.Core/Data/OrchestratingRepository.cs
+++ b/src/Premotion.Mansion.Core/Data/OrchestratingRepository.cs
@@ -187,11 +187,11 @@ namespace Premotion.Mansion.Core.Data
 		protected override void DoUpdateNode(IMansionContext context, Node node, IPropertyBag modifiedProperties)
 		{
 			// store the record
-			var updated = storageEngine.UpdateNode(context, node, modifiedProperties);
+			node = storageEngine.UpdateNode(context, node, modifiedProperties);
 
 			// index the record
 			foreach (var indexer in indexEngines)
-				indexer.Index(context, updated);
+				indexer.Index(context, node);
 		}
 		/// <summary>
 		/// Deletes an existing node from this repository.


### PR DESCRIPTION
In the method DoAfterUpdate in Listeners the given Node did not contain the modified properties.
There is however a propertybag containing the correct modified properties, but on a AfterUpdate I would expect to have an updated node.
