### PR TITLE
Moved some settings to Constants for the StandardMailService.

### DIFF
--- a/src/Premotion.Mansion.Core/Constants.cs
+++ b/src/Premotion.Mansion.Core/Constants.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Configuration;
+
+namespace Premotion.Mansion.Core
+{
+	/// <summary>
+	/// 
+	/// </summary>
+	public static class Constants
+	{
+		/// <summary>
+		/// Indicating whether the application is live (true) or in staging mode (false).
+		/// </summary>
+		public static bool ApplicationIsLive = Convert.ToBoolean(ConfigurationManager.AppSettings["APPLICATION_IS_LIVE"]);
+		
+	}
+}

--- a/src/Premotion.Mansion.Core/Premotion.Mansion.Core.csproj
+++ b/src/Premotion.Mansion.Core/Premotion.Mansion.Core.csproj
@@ -56,6 +56,7 @@
   <ItemGroup>
     <Compile Include="ApplicationSettingsConstants.cs" />
     <Compile Include="Collections\DatasetReader.cs" />
+    <Compile Include="Constants.cs" />
     <Compile Include="Conversion\Converters\GuidToStringConverter.cs" />
     <Compile Include="Conversion\Converters\JObjectToNodePointerConverter.cs" />
     <Compile Include="Conversion\Converters\Serializers.cs" />

--- a/src/Premotion.Mansion.Web/Mail/Constants.cs
+++ b/src/Premotion.Mansion.Web/Mail/Constants.cs
@@ -16,7 +16,6 @@ namespace Premotion.Mansion.Web.Mail
 		/// The name or IP address of the host used for SMTP transactions.
 		/// </summary>
 		public static string SmtpHost = ConfigurationManager.AppSettings["SMTP_HOST"];
-
 		/// <summary>
 		/// The port used for SMTP transactions.
 		/// </summary>
@@ -33,5 +32,9 @@ namespace Premotion.Mansion.Web.Mail
 		/// The password for the SMTP network credentials.
 		/// </summary>
 		public static string SmtpPassword = ConfigurationManager.AppSettings["SMTP_PASSWORD"];
+		/// <summary>
+		/// The staging e-mail address.
+		/// </summary>
+		public static string StagingEmail = ConfigurationManager.AppSettings["stagingEmail"];
 	}
 }

--- a/src/Premotion.Mansion.Web/Mail/Standard/StandardMailService.cs
+++ b/src/Premotion.Mansion.Web/Mail/Standard/StandardMailService.cs
@@ -49,9 +49,7 @@ namespace Premotion.Mansion.Web.Mail.Standard
 			CheckDisposed();
 
 			// if the application is not live, capture all mail
-			var application = context.Stack.Peek<IPropertyBag>(ApplicationSettingsConstants.DataspaceName);
-			var isApplicationStaging = !application.Get(context, ApplicationSettingsConstants.IsLiveApplicationSetting, false);
-			if (isApplicationStaging)
+			if (Core.Constants.ApplicationIsLive)
 			{
 				var subject = new StringBuilder();
 				subject.Append("[staging - to:");
@@ -68,8 +66,8 @@ namespace Premotion.Mansion.Web.Mail.Standard
 				message.Bcc.Clear();
 
 				// set the staging e-mail addresses
-				string stagingEmailAddresses;
-				if (!application.TryGet(context, "stagingEmail", out stagingEmailAddresses) || string.IsNullOrEmpty(stagingEmailAddresses))
+				var stagingEmailAddresses = Constants.StagingEmail;
+				if (string.IsNullOrEmpty(stagingEmailAddresses))
 					stagingEmailAddresses = "support@premotion.nl";
 				message.To.Add(stagingEmailAddresses, string.Empty);
 			}


### PR DESCRIPTION
@devatwork Is it OK to merge this one into master? For now, this removes the dependency a new MansionContext StandardMailService is missing on the ApplicationSettings dataspace, thus fixing the DataspaceNotFoundException that would be thrown.
