### PR TITLE
Move the JobConfiguration  form procedure so it won't be rendered after ...

### DIFF
--- a/src/Premotion.Mansion.Scheduler/Web/Types/Job/Job.xform
+++ b/src/Premotion.Mansion.Scheduler/Web/Types/Job/Job.xform
@@ -14,8 +14,8 @@
 		</forms:fieldset>
 
 		<invokeProcedure procedureName="JobTrigger" />
-		<invokeProcedure procedureName="JobErrorHandling" />
 		<invokeProcedure procedureName="JobConfiguration" />
+		<invokeProcedure procedureName="JobErrorHandling" />
 		<invokeProcedure procedureName="JobStatus" />
 		<invokeProcedure procedureName="IncludeGroupPublication"/>
 		<invokeProcedure procedureName="IncludeGroupIdentity"/>


### PR DESCRIPTION
...the JobErrorHandling configuration.

Just so the settings aren't part of the JobErrorHandling configuration.
