### PR TITLE
Refine logic to determine the context location flag

### DIFF
--- a/src/Premotion.Mansion.Web/MansionWebContext.cs
+++ b/src/Premotion.Mansion.Web/MansionWebContext.cs
@@ -48,7 +48,10 @@ namespace Premotion.Mansion.Web
 			Stack.Push("Request", requestUrlProperties, true);
 
 			// set context location flag
-			IsBackoffice = request.RequestUrl.PathSegments.Length > 0 && request.RequestUrl.PathSegments[0].Equals(Constants.BackofficeUrlPrefix, StringComparison.OrdinalIgnoreCase);
+			var backofficeRequest = request.RequestUrl.PathSegments.Length > 0 && request.RequestUrl.PathSegments[0].Equals(Constants.BackofficeUrlPrefix, StringComparison.OrdinalIgnoreCase);
+			var backofficeReferrerRequest = request.ReferrerUrl != null && request.ReferrerUrl.PathSegments.Length > 0 && request.ReferrerUrl.PathSegments[0].Equals(Constants.BackofficeUrlPrefix, StringComparison.OrdinalIgnoreCase);
+
+			IsBackoffice = (backofficeRequest || backofficeReferrerRequest);
 
 			// initialize the context
 			IPropertyBag applicationSettings;

--- a/src/Premotion.Mansion.Web/MansionWebContext.cs
+++ b/src/Premotion.Mansion.Web/MansionWebContext.cs
@@ -47,11 +47,18 @@ namespace Premotion.Mansion.Web
 				requestUrlProperties.Set("referrerUrl", request.ReferrerUrl);
 			Stack.Push("Request", requestUrlProperties, true);
 
-			// set context location flag
+			// determine if current context location is backoffice based on the request url
 			var backofficeRequest = request.RequestUrl.PathSegments.Length > 0 && request.RequestUrl.PathSegments[0].Equals(Constants.BackofficeUrlPrefix, StringComparison.OrdinalIgnoreCase);
-			var backofficeReferrerRequest = request.ReferrerUrl != null && request.ReferrerUrl.PathSegments.Length > 0 && request.ReferrerUrl.PathSegments[0].Equals(Constants.BackofficeUrlPrefix, StringComparison.OrdinalIgnoreCase);
 
-			IsBackoffice = (backofficeRequest || backofficeReferrerRequest);
+			// determine if current context location is backoffice based on the referrer and route
+			if (!backofficeRequest) {
+				var backofficeReferrer = request.ReferrerUrl != null && request.ReferrerUrl.PathSegments.Length > 0 && request.ReferrerUrl.PathSegments[0].Equals(Constants.BackofficeUrlPrefix, StringComparison.OrdinalIgnoreCase);
+				var routeRequest = request.RequestUrl.PathSegments.Length > 0 && request.RequestUrl.PathSegments[0].Equals(Dispatcher.Constants.RouteUrlPrefix, StringComparison.OrdinalIgnoreCase);
+				backofficeRequest = backofficeReferrer && routeRequest;
+			}
+
+			// set context location flag
+			IsBackoffice = backofficeRequest;
 
 			// initialize the context
 			IPropertyBag applicationSettings;


### PR DESCRIPTION
This will set a backoffice context for routes from CMS, like the NodeSelector.

The case that will be fixed with this change is that the CMS node selector will now query based on a backoffice context. This will prevent nodes to not show up because the visitor role has no rights on specific node results.